### PR TITLE
ci: update to latest runner images

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -64,21 +64,21 @@ rulesets:
             - integration_id: 15368
               context: build
             - integration_id: 15368
-              context: test-local-tarball (ubuntu-22.04, lts/fermium)
+              context: test-local-tarball (ubuntu-24.04, lts/fermium)
             - integration_id: 15368
-              context: test-local-tarball (ubuntu-22.04, lts/gallium)
+              context: test-local-tarball (ubuntu-24.04, lts/gallium)
             - integration_id: 15368
-              context: test-local-tarball (ubuntu-22.04, lts/hydrogen)
+              context: test-local-tarball (ubuntu-24.04, lts/hydrogen)
             - integration_id: 15368
-              context: test-local-tarball (ubuntu-22.04, lts/iron)
+              context: test-local-tarball (ubuntu-24.04, lts/iron)
             - integration_id: 15368
-              context: test-local-tarball (macos-12, lts/fermium)
+              context: test-local-tarball (macos-14-large, lts/fermium)
             - integration_id: 15368
-              context: test-local-tarball (macos-12, lts/gallium)
+              context: test-local-tarball (macos-14-large, lts/gallium)
             - integration_id: 15368
-              context: test-local-tarball (macos-12, lts/hydrogen)
+              context: test-local-tarball (macos-14-large, lts/hydrogen)
             - integration_id: 15368
-              context: test-local-tarball (macos-12, lts/iron)
+              context: test-local-tarball (macos-14-large, lts/iron)
             # - integration_id: 15368
             #   context: test-local-tarball (macos-14, lts/fermium)
             - integration_id: 15368

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
 
     steps:
@@ -54,7 +54,7 @@ jobs:
   build:
     needs:
       - lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
 
     steps:
@@ -97,8 +97,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
-          - macos-12
+          - ubuntu-24.04
+          - macos-14-large
           - macos-14 # ARM64
           - windows-2022
         node:
@@ -164,7 +164,7 @@ jobs:
   test-local-registry:
     needs:
       - build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     services:
       registry:

--- a/.github/workflows/deps-automerge.yml
+++ b/.github/workflows/deps-automerge.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   automerge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'loozhengyuan' }}
 


### PR DESCRIPTION
This commit updates all runner images to the latest variants:

- `ubuntu-22.04` -> `ubuntu-24.04`
- `macos-12` -> `macos-14-large`

NOTE: The `-large` suffixed macOS runner images[1] refers to the traditional `amd64` CPU architecture.

[1]: https://github.com/actions/runner-images